### PR TITLE
Added error catching for when convergence fails

### DIFF
--- a/fitr/inference/mle_parallel.py
+++ b/fitr/inference/mle_parallel.py
@@ -46,6 +46,7 @@ def l_bfgs_b(f,
     niters  = 0
     nstarts = 0
     done    = False
+    succeeded = False
     while not done:
         xinit = np.random.normal(0, init_sd, size=nparams)
         res = minimize(nlog_prob, xinit, method='L-BFGS-B')
@@ -62,9 +63,12 @@ def l_bfgs_b(f,
                 hess_inv = res.hess_inv.todense()
                 lme_ = lme(fmin, nparams, hess_inv)
                 bic_ = bic(fmin, nparams, data[i].shape[1])
+                succeeded = True
         else:
             done = True
             print('Subject %s Fit | %s Starts | lp_= %s' %(i, nstarts, fmin))
+    if succeeded is False:
+        raise(ValueError('Failed to converge'))
 
     return i, xmin, fmin, fevals, niters, lme_, bic_, hess_inv
 

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -1,0 +1,16 @@
+import numpy as np
+from fitr.inference import mlepar
+import pytest
+
+def bad_loglik(x, D):
+    i = x[0]
+    j = x[1]
+    return 10*i*np.random.random()-0.5 + 10*j*np.random.random()-0.5
+
+dummy_subject_data = np.random.random((50,5,2))
+
+#Test that should have at least some failures to do loglik function returning
+#random values
+def test_failure():
+    with pytest.raises(ValueError):
+        return mlepar(bad_loglik, dummy_subject_data, nparams=2,maxstarts=2)


### PR DESCRIPTION
-sometimes mlepar would fail to converge for a subject resulting in an
unclear error
-this update adds a test to make sure we catch these cases and raises a
clear error message when it happens now